### PR TITLE
Add a check for mpi4py version during Cython compilation.

### DIFF
--- a/pymusic/Makefile.am
+++ b/pymusic/Makefile.am
@@ -1,14 +1,18 @@
 
-EXTRA_DIST = setup.py.in pymusic.pyx pymusic.pxd music_c.h pybuffer.pyx pybuffer.pxd
+EXTRA_DIST = setup.py.in tests.py pymusic.pyx pymusic.pxd music_c.h pybuffer.pyx pybuffer.pxd 
 
 BUILT_SOURCES = pymusic.cpp pybuffer.cpp
 
-pybuffer.cpp: pybuffer.pyx pybuffer.pxd
+
+pyconfig.pxi: tests.py
+	cd $(top_srcdir)/pymusic; $(PYTHON) tests.py
+
+pybuffer.cpp: pyconfig.pxi pybuffer.pyx pybuffer.pxd 
 	cd $(top_srcdir)/pymusic; $(PYTHON) -c \
 	"from Cython.Build import cythonize; \
 	cythonize('pybuffer.pyx', verbose=1)"
 
-pymusic.cpp: pymusic.pyx pymusic.pxd
+pymusic.cpp: pyconfig.pxi pymusic.pyx pymusic.pxd 
 	cd $(top_srcdir)/pymusic; $(PYTHON) -c \
 	"from Cython.Build import cythonize; \
 	cythonize('pymusic.pyx', verbose=1)"

--- a/pymusic/pybuffer.pxd
+++ b/pymusic/pybuffer.pxd
@@ -3,8 +3,12 @@
 cdef extern from "mpi_compat.h":
     pass
 
+include "pyconfig.pxi" 
 cimport mpi4py.MPI as MPI
-from mpi4py.mpi_c cimport *
+IF MPI4V2:
+    from mpi4py.libmpi cimport *
+ELSE:
+    from mpi4py.mpi_c cimport *
 
 cdef extern from "music/pymusic_c.h":
     object PyUnicodeString_FromString(const char*)

--- a/pymusic/pymusic.pxd
+++ b/pymusic/pymusic.pxd
@@ -3,8 +3,12 @@
 cdef extern from "mpi_compat.h":
     pass
 
+include "pyconfig.pxi" 
 cimport mpi4py.MPI as MPI
-from mpi4py.mpi_c cimport *
+IF MPI4V2:
+    from mpi4py.libmpi cimport *
+ELSE:
+    from mpi4py.mpi_c cimport *
 
 from libcpp cimport bool as cbool
 from libcpp.string cimport string

--- a/pymusic/tests.py
+++ b/pymusic/tests.py
@@ -1,0 +1,10 @@
+# compile time python tests
+
+# Test mpi4py version
+import mpi4py
+from distutils.version import LooseVersion
+is_v2 = LooseVersion(mpi4py.__version__) > LooseVersion("1.3.1")
+
+# Write configuration file 
+with open("pyconfig.pxi", "w") as f: 
+	f.write("DEF MPI4V2 = {0}".format(is_v2))


### PR DESCRIPTION
Version 2 of mpi4py has changed the name of a submodule from mpi_c to
libmpi. We need to check which one to use at compile time.

This suggested fix is quite ugly. I would be grateful for any suggestions of improving the way we check for versions without a separate compile-time python script file. I've tried variations on checking it right in the Makefile, but haven't been able to make Python run the check.
