### PR TITLE
Allow multiple Setup instances

### DIFF
--- a/pymusic/examples/receivers.py
+++ b/pymusic/examples/receivers.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 
 import music
 

--- a/pymusic/pymusic.pxd
+++ b/pymusic/pymusic.pxd
@@ -119,6 +119,7 @@ cdef extern from "music/setup.hh" namespace "MUSIC":
         CSetup(int&, char**&, int, int*) except +
 
         cbool config(string, string*)
+        cbool isLastSetupInstance()
 
         CContInputPort*     publishContInput(string)
         CContOutputPort*    publishContOutput(string)
@@ -126,6 +127,7 @@ cdef extern from "music/setup.hh" namespace "MUSIC":
         CEventOutputPort*   publishEventOutput(string)
         CMessageInputPort*  publishMessageInput(string)
         CMessageOutputPort* publishMessageOutput(string)
+        
 
 cdef extern from "music/runtime.hh" namespace "MUSIC":
     cdef cppclass CRuntime "MUSIC::Runtime":

--- a/src/music/runtime.hh
+++ b/src/music/runtime.hh
@@ -74,7 +74,7 @@ namespace MUSIC
     typedef std::vector<Connection*> Connections;
     bool needsMultiCommunication ();
     void
-    takeTickingPorts (Setup* s);
+    takeTickingPorts ();
     void
     connectToPeers (Connections* connections);
     void

--- a/src/music/setup.hh
+++ b/src/music/setup.hh
@@ -42,6 +42,35 @@ namespace MUSIC {
 
   class Runtime;
 
+  struct SetupData
+  {
+    SetupData()
+        : comm(),
+        config_(NULL),
+        ports_(),
+        connections_(),
+        temporalNegotiator_(NULL),
+        argc_(),
+        argv_(NULL),
+        launchedByMusic_(false),
+        postponeSetup_(false),
+        timebase_(0.0),
+        isInstantiated_(true)
+      {}
+
+    MPI::Intracomm comm_;
+    Configuration* config_;
+    std::vector<Port*> ports_;
+    std::vector<Connection*>* connections_;
+    TemporalNegotiator* temporalNegotiator_;
+    int argc_;
+    char** argv_;
+    bool launchedByMusic_;
+    bool postponeSetup_;
+    double timebase_;
+    static bool isInstantiated_;
+  };
+
   /*
    * This is the Setup object in the MUSIC API
    *
@@ -52,6 +81,8 @@ namespace MUSIC {
     static const char* const configEnvVarName;
     static const char* const opConfigFileName;
     static const char* const opAppLabel;
+    static bool isInstantiated_;
+
   public:
     Setup (int& argc, char**& argv);
 
@@ -80,18 +111,7 @@ namespace MUSIC {
     MessageOutputPort* publishMessageOutput (string identifier);
 
   private:
-    MPI::Intracomm comm;
-    Configuration* config_;
-    std::vector<Port*> ports_;
-    std::vector<Connection*>* connections_;
-    TemporalNegotiator* temporalNegotiator_;
-    double timebase_;
-    static bool isInstantiated_;
-    int& argc_;
-    char**& argv_;
-
-    bool launchedByMusic_;
-    bool postponeSetup_;
+    static SetupData data_;
 
     // Since we don't want to expose this internal interface to the
     // user we put the member functions in the private part and give
@@ -106,7 +126,7 @@ namespace MUSIC {
     friend class TemporalNegotiator;
     friend class ApplicationNode;
     
-    double timebase () { return timebase_; }
+    double timebase () { return data_.timebase_; }
 
     bool launchedByMusic ();
 
@@ -139,19 +159,19 @@ namespace MUSIC {
 
     std::vector<Port*>* ports ()
     {
-      return &ports_;
+      return &data_.ports_;
     }    
 
     void addPort (Port* p);
     
     std::vector<Connection*>* connections ()
     {
-      return connections_;
+      return data_.connections_;
     }
     
     void addConnection (Connection* c);
 
-    TemporalNegotiator* temporalNegotiator () { return temporalNegotiator_; }
+    TemporalNegotiator* temporalNegotiator () { return data_.temporalNegotiator_; }
     
     void errorChecks ();
 

--- a/src/music/setup.hh
+++ b/src/music/setup.hh
@@ -145,7 +145,7 @@ namespace MUSIC {
 
   private:
     static GlobalSetupData data_;
-    MPI::Intracomm comm_;
+    static MPI::Intracomm comm_;
     std::vector<Port*> ports_;
     std::vector<Connection*> connections_;
     // Since we don't want to expose this internal interface to the

--- a/src/music/setup.hh
+++ b/src/music/setup.hh
@@ -56,7 +56,7 @@ namespace MUSIC {
         argv_(NULL),
         launchedByMusic_(false),
         postponeSetup_(false),
-        timebase_()
+        timebase_(0.0)
       {
       }
 
@@ -65,27 +65,11 @@ namespace MUSIC {
   {
       if (launchedByMusic_ )
       {
-          //delete temporalNegotiator_;
+          delete temporalNegotiator_;
       }
 
-      //delete config_;
-      //delete argv_;
-
-	   for (std::vector<Port*>::iterator i = ports_.begin ();
-           i != ports_.end ();
-           ++i)
-       {
-       
-         //   (*i)->setupCleanup ();
-       }
-
-      // delete connection objects
-      for (std::vector<Connection*>::iterator i = connections_.begin ();
-           i != connections_.end ();
-           ++i)
-      {
-        //delete *i; 
-      }
+      delete config_;
+      delete argv_;
   }
 
     MPI::Intracomm comm_;
@@ -192,17 +176,21 @@ namespace MUSIC {
 
     std::vector<Port*>* ports ()
     {
-      return new std::vector<Port*>(data_->ports_);
+      //return new std::vector<Port*>(data_->ports_.begin(), data_->ports_.end());
+      return &data_->ports_;
     }    
 
     void addPort (Port* p);
     
     std::vector<Connection*>* connections ()
     {
-      return new std::vector<Connection*>(data_->connections_);
+      //return new std::vector<Connection*>(data_->connections_.begin(), data_->connections_.end());
+      return &data_->connections_;
     }
-    
+
     void addConnection (Connection* c);
+
+    void clearSetupData();
 
     TemporalNegotiator* temporalNegotiator () { return data_->temporalNegotiator_; }
     

--- a/src/music/setup.hh
+++ b/src/music/setup.hh
@@ -145,7 +145,7 @@ namespace MUSIC {
 
   private:
     static GlobalSetupData data_;
-    static MPI::Intracomm* comm_;
+    MPI::Intracomm comm_;
     std::vector<Port*> ports_;
     std::vector<Connection*> connections_;
     // Since we don't want to expose this internal interface to the

--- a/src/runtime.cc
+++ b/src/runtime.cc
@@ -61,12 +61,27 @@ namespace MUSIC
     /* remedius
      * copy ports in order to delete them afterwards (it was probably a memory leak in previous revision)
      */
-    std::vector<Port*> p = s->global_ports();
-    for (std::vector<Port *>::iterator it = p.begin ();
-        it < p.end (); it++)
-      ports.push_back ( (*it));
+    std::vector<Setup*> all_setups = Setup::get_all_setups();
+    Connections* connections = new std::vector<Connection*>();
+    for( std::vector<Setup*>::iterator setup_it = all_setups.begin(); setup_it != all_setups.end(); setup_it++)
+    {
 
-    Connections* connections = s->connections ();
+        std::vector<Port*> p = (*setup_it)->ports();
+        for (std::vector<Port *>::iterator it = p.begin ();
+            it < p.end (); it++)
+        {
+          ports.push_back ( (*it));
+        }
+        (*setup_it)->clearPorts();
+
+        std::vector<Connection*> c = (*setup_it)->connections();
+        for (std::vector<Connection *>::iterator it = c.begin ();
+            it < c.end (); it++)
+        {
+          connections->push_back ( (*it));
+        }
+       (*setup_it)->clearConnections();
+    }
 
     scheduler = new Scheduler (comm, leader_);
     if (s->launchedByMusic ())
@@ -111,7 +126,10 @@ namespace MUSIC
 	scheduler->initializeAgentState ();
       }
 
-    delete s;
+    for( std::vector<Setup*>::iterator setup_it = all_setups.begin(); setup_it != all_setups.end(); setup_it++)
+    {
+        //delete *setup_it;
+    }
 #ifdef MUSIC_AFTER_RUNTIME_CONSTRUCTOR_REPORT
     if (MPI::COMM_WORLD.Get_rank () == 0)
     reportMem ();

--- a/src/runtime.cc
+++ b/src/runtime.cc
@@ -61,8 +61,9 @@ namespace MUSIC
     /* remedius
      * copy ports in order to delete them afterwards (it was probably a memory leak in previous revision)
      */
-    for (std::vector<Port *>::iterator it = s->ports ()->begin ();
-        it < s->ports ()->end (); it++)
+    std::vector<Port*> p = s->global_ports();
+    for (std::vector<Port *>::iterator it = p.begin ();
+        it < p.end (); it++)
       ports.push_back ( (*it));
 
     Connections* connections = s->connections ();

--- a/src/runtime.cc
+++ b/src/runtime.cc
@@ -128,7 +128,7 @@ namespace MUSIC
 
     for( std::vector<Setup*>::iterator setup_it = all_setups.begin(); setup_it != all_setups.end(); setup_it++)
     {
-        //delete *setup_it;
+        delete *setup_it;
     }
 #ifdef MUSIC_AFTER_RUNTIME_CONSTRUCTOR_REPORT
     if (MPI::COMM_WORLD.Get_rank () == 0)

--- a/src/runtime.cc
+++ b/src/runtime.cc
@@ -61,27 +61,11 @@ namespace MUSIC
     /* remedius
      * copy ports in order to delete them afterwards (it was probably a memory leak in previous revision)
      */
-    std::vector<Setup*> all_setups = Setup::get_all_setups();
-    Connections* connections = new std::vector<Connection*>();
-    for( std::vector<Setup*>::iterator setup_it = all_setups.begin(); setup_it != all_setups.end(); setup_it++)
-    {
+    for (std::vector<Port *>::iterator it = s->ports ()->begin ();
+        it < s->ports ()->end (); it++)
+      ports.push_back ( (*it));
 
-        std::vector<Port*> p = (*setup_it)->ports();
-        for (std::vector<Port *>::iterator it = p.begin ();
-            it < p.end (); it++)
-        {
-          ports.push_back ( (*it));
-        }
-        (*setup_it)->clearPorts();
-
-        std::vector<Connection*> c = (*setup_it)->connections();
-        for (std::vector<Connection *>::iterator it = c.begin ();
-            it < c.end (); it++)
-        {
-          connections->push_back ( (*it));
-        }
-       (*setup_it)->clearConnections();
-    }
+    Connections* connections = s->connections ();
 
     scheduler = new Scheduler (comm, leader_);
     if (s->launchedByMusic ())
@@ -126,10 +110,7 @@ namespace MUSIC
 	scheduler->initializeAgentState ();
       }
 
-    for( std::vector<Setup*>::iterator setup_it = all_setups.begin(); setup_it != all_setups.end(); setup_it++)
-    {
-        delete *setup_it;
-    }
+    //delete s;
 #ifdef MUSIC_AFTER_RUNTIME_CONSTRUCTOR_REPORT
     if (MPI::COMM_WORLD.Get_rank () == 0)
     reportMem ();
@@ -458,6 +439,7 @@ namespace MUSIC
         connector != connectors.end (); ++connector)
       (*connector)->freeIntercomm ();
 
+    
     MPI::Finalize ();
   }
 

--- a/src/runtime.cc
+++ b/src/runtime.cc
@@ -61,16 +61,19 @@ namespace MUSIC
     /* remedius
      * copy ports in order to delete them afterwards (it was probably a memory leak in previous revision)
      */
+
     for (std::vector<Port *>::iterator it = s->ports ()->begin ();
         it < s->ports ()->end (); it++)
+    {
       ports.push_back ( (*it));
+    }
 
     Connections* connections = s->connections ();
 
     scheduler = new Scheduler (comm, leader_);
     if (s->launchedByMusic ())
       {
-        takeTickingPorts (s);
+        takeTickingPorts ();
 
         // create a total order for connectors and
         // establish connection to peers
@@ -110,6 +113,7 @@ namespace MUSIC
 	scheduler->initializeAgentState ();
       }
 
+    s->clearSetupData();
     //delete s;
 #ifdef MUSIC_AFTER_RUNTIME_CONSTRUCTOR_REPORT
     if (MPI::COMM_WORLD.Get_rank () == 0)
@@ -160,7 +164,7 @@ namespace MUSIC
   }
 
   void
-  Runtime::takeTickingPorts (Setup* s)
+  Runtime::takeTickingPorts ()
   {
     std::vector<Port*>::iterator p;
     for (p = ports.begin (); p != ports.end (); ++p)

--- a/src/setup.cc
+++ b/src/setup.cc
@@ -29,7 +29,7 @@
 namespace MUSIC {
 
 
-  GlobalSetupData* Setup::data_ = new GlobalSetupData();
+  GlobalSetupData* Setup::data_ = NULL;
   size_t Setup::instanceCount = 0;
   static std::string err_MPI_Init = "MPI_Init was called before the Setup constructor";
   const char* const Setup::opConfigFileName = "--music-config";
@@ -41,6 +41,7 @@ namespace MUSIC {
     Setup::instanceCount++;
     if( Setup::instanceCount == 1 )
     {
+        Setup::data_ = new GlobalSetupData();
         data_->argc_ = argc;
         data_->argv_ = argv;
         if (MPI::Is_initialized ())
@@ -57,6 +58,7 @@ namespace MUSIC {
     Setup::instanceCount++;
     if( Setup::instanceCount == 1 )
     {
+        Setup::data_ = new GlobalSetupData();
         data_->argc_ = argc;
         data_->argv_ = argv;
         if (MPI::Is_initialized ())
@@ -126,7 +128,7 @@ namespace MUSIC {
       data_->config_ = new Configuration ();
 
 
-     //data_->connections_ = new std::vector<Connection*>; // destroyed by runtime
+    //data_->connections_ = new std::vector<Connection*>; // destroyed by runtime
     if (launchedByMusic ())
       {
         // launched by the music utility
@@ -453,6 +455,11 @@ namespace MUSIC {
     data_->connections_.push_back (c);
   }
 
+  void Setup::clearSetupData()
+  {
+      data_->connections_.clear();
+      data_->ports_.clear();
+  }
 
 
 }

--- a/src/setup.cc
+++ b/src/setup.cc
@@ -29,7 +29,6 @@
 namespace MUSIC {
 
 
-  MPI::Intracomm* Setup::comm_;
   GlobalSetupData Setup::data_;
   static std::string err_MPI_Init = "MPI_Init was called before the Setup constructor";
   const char* const Setup::opConfigFileName = "--music-config";
@@ -38,6 +37,7 @@ namespace MUSIC {
 
   Setup::Setup (int& argc, char**& argv)
   {
+    comm_ = MPI::COMM_NULL;
     if( data_.setups_.size() == 0 )
     {
         data_.argc_ = argc;
@@ -55,6 +55,7 @@ namespace MUSIC {
   Setup::Setup (int& argc, char**& argv, int required, int* provided)
   {
       
+    comm_ = MPI::COMM_NULL;
     if( data_.setups_.size() == 0 )
     {
         data_.argc_ = argc;
@@ -147,12 +148,12 @@ namespace MUSIC {
             argc = data_.argc_;
             argv = data_.argv_;
           }
-        comm_ = new MPI::Intracomm(MPI::COMM_WORLD.Split (data_.config_->Color (), myRank));
+        comm_ = MPI::COMM_WORLD.Split (data_.config_->Color (), myRank);
       }
     else
       {
         // launched with mpirun
-        comm_ = &MPI::COMM_WORLD;
+        comm_ = MPI::COMM_WORLD;
         data_.timebase_ = MUSIC_DEFAULT_TIMEBASE;
       }
   }
@@ -323,7 +324,7 @@ namespace MUSIC {
   MPI::Intracomm
   Setup::communicator ()
   {
-    return *comm_;
+    return comm_;
   }
 
 
@@ -365,7 +366,7 @@ namespace MUSIC {
   int
   Setup::nProcs ()
   {
-    return comm_->Get_size ();
+    return comm_.Get_size ();
   }
 
 

--- a/src/setup.cc
+++ b/src/setup.cc
@@ -30,6 +30,7 @@ namespace MUSIC {
 
 
   GlobalSetupData Setup::data_;
+  MPI::Intracomm Setup::comm_;
   static std::string err_MPI_Init = "MPI_Init was called before the Setup constructor";
   const char* const Setup::opConfigFileName = "--music-config";
   const char* const Setup::opAppLabel = "--app-label";
@@ -37,7 +38,6 @@ namespace MUSIC {
 
   Setup::Setup (int& argc, char**& argv)
   {
-    comm_ = MPI::COMM_NULL;
     if( data_.setups_.size() == 0 )
     {
         data_.argc_ = argc;
@@ -55,7 +55,6 @@ namespace MUSIC {
   Setup::Setup (int& argc, char**& argv, int required, int* provided)
   {
       
-    comm_ = MPI::COMM_NULL;
     if( data_.setups_.size() == 0 )
     {
         data_.argc_ = argc;


### PR DESCRIPTION
- This fix allows users to use the python bindings to create ports and get configuration variables even if they are already running a music enabled simulator instance.
- The changes causes a exception (which is suppressed) in the python bindings,  e.g.

> Exception AttributeError: "'pymusic.ContOutputPort' object has no attribute 'ptr'" in 'pymusic.Setup.**dealloc**' ignored. 

I could not fix it until now but except from a warning when shutting down the application it does not cause problems. 
