### PR TITLE
Change needed for compilation with gcc-6

### DIFF
--- a/src/connectivity.cc
+++ b/src/connectivity.cc
@@ -30,6 +30,10 @@ namespace MUSIC {
 
   int ConnectorInfo::maxPortCode_;
 
+#if __cplusplus <=199711L
+  ConnectivityInfo* const Connectivity::NO_CONNECTIVITY = NULL;
+#endif
+
   void
   ConnectorInfo::registerPortCode (int portCode)
   {

--- a/src/music/connectivity.hh
+++ b/src/music/connectivity.hh
@@ -207,7 +207,11 @@ namespace MUSIC {
     {
     }
 
-    static const int NO_CONNECTIVITY = 0;
+#if __cplusplus > 199711L
+    static constexpr ConnectivityInfo* NO_CONNECTIVITY = nullptr;
+#else
+    static const ConnectivityInfo* NO_CONNECTIVITY = NULL;
+#endif
 
     void  add (std::string localPort, ConnectivityInfo::PortDirection dir, int width,
         std::string recApp, std::string recPort, int recPortCode,

--- a/src/music/connectivity.hh
+++ b/src/music/connectivity.hh
@@ -210,7 +210,7 @@ namespace MUSIC {
 #if __cplusplus > 199711L
     static constexpr ConnectivityInfo* NO_CONNECTIVITY = nullptr;
 #else
-    static const ConnectivityInfo* NO_CONNECTIVITY = NULL;
+    static ConnectivityInfo* const NO_CONNECTIVITY;
 #endif
 
     void  add (std::string localPort, ConnectivityInfo::PortDirection dir, int width,


### PR DESCRIPTION
Compilation with strict C++11, for example gcc-6, does not allow mixing int and pointer types. The constant NO_CONNECTIVITY is defined as an int with value zero, but used to compare with valid pointers. This patch changes the constant to be a pointer.

Further, gcc-6 requires that the value is declared constexpr to state that it can be fully computed at compiletime. This is placed under conditional compilation to allow for old compilers without support for constexpr.
