### PR TITLE
Fix POSTPONE Setup

### DIFF
--- a/music-config/__init__.py
+++ b/music-config/__init__.py
@@ -16,6 +16,6 @@
 #  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from predict_rank import predictRank
+from music import predictRank
 from config import launchedByMusic, supersedeArgv, postponeSetup, \
                    define, Application, connect, configure, launch

--- a/music-config/config.py
+++ b/music-config/config.py
@@ -241,7 +241,6 @@ def configure ():
     os.environ[CONFIGVARNAME] = conf
 
     configured = True
-    print "Config string is \n{}".format(conf)
 
     
 def launch ():

--- a/music-config/config.py
+++ b/music-config/config.py
@@ -21,7 +21,7 @@
 
 import os
 
-from music.predict_rank import predictRank
+from music import predictRank
 
 # This function now defined in predict_rank.py
 #
@@ -241,6 +241,7 @@ def configure ():
     os.environ[CONFIGVARNAME] = conf
 
     configured = True
+    print "Config string is \n{}".format(conf)
 
     
 def launch ():

--- a/pymusic/pyconfig.pxi
+++ b/pymusic/pyconfig.pxi
@@ -1,0 +1,1 @@
+DEF MPI4V2 = True

--- a/src/application_map.cc
+++ b/src/application_map.cc
@@ -123,6 +123,7 @@ namespace MUSIC {
     int size = MPI::COMM_WORLD.Get_size ();
     int my_rank = MPI::COMM_WORLD.Get_rank ();
     int *colors = new int[size];
+	ApplicationInfo* app = lookup (my_app_label);
     colors[my_rank] = lookup (my_app_label)->color ();
     MPI::COMM_WORLD.Allgather (MPI::IN_PLACE, 0, MPI::INT, colors, 1, MPI::INT);
 

--- a/src/music/setup.hh
+++ b/src/music/setup.hh
@@ -112,6 +112,8 @@ namespace MUSIC {
 
     void init (int& argc, char**& argv);
 
+    void init_comm ();
+
     void maybeProcessMusicArgv (int& argc, char**& argv);
 
     void maybePostponedSetup ();


### PR DESCRIPTION
@mdjurfeldt This PR is not really meant to merge as it is now bug to share the code in order for collaborative debugging; 

A fixed PyNN 0.8.1 fork with MUSIC simulator support can be found here:

https://github.com/HBPNeurorobotics/PyNN.git  
(music_port_0.8.1 branch)

If there are any issues regarding PyNN and MUSIC compatibility please let me know. 

For debugging Ive choosen the example 'music_simple.py' from the PyNN subfolder /examples but of course you are free to use any other as well. However, this music_simple.py is modified such that two NEST simulators are launched instead of a NEST/NEURON pair

---

In the current version both NEST instances do start independently and it looks like the _MUSIC_CONFIG_ is passed and parsed but I get some segmentation faults; 

In general I use the following to debug in MPI environments:

`mpiexec -np 2 xterm -e "gdb gdb.in python"`
in the file gdb.in:

set breakpoint pending on
break MUSIC::Setup::init
run music_simple.py 

if you have more advanced debugging techniques please let me know, thank you!
