### PR TITLE
Compiling MUSIC on macOS/OSX

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -393,6 +393,8 @@ AC_SUBST(LAUNCHSTYLE)
 AM_CONDITIONAL([LAUNCHSTYLE_SET], [test ! -z "$LAUNCHSTYLE"])
 #AC_SUBST([TEST_SH_LIST])
 
+AM_CONDITIONAL([DARWIN], [test $(uname) = Darwin])
+
 AC_CONFIG_FILES([
   Makefile
   mpidep/Makefile

--- a/utils/Makefile.am
+++ b/utils/Makefile.am
@@ -8,6 +8,14 @@ EXTRA_PROGRAMS = eventsource eventsink eventselect \
 				eventgenerator eventcounter eventlogger \
 				contsink messagesource viewevents
 
+if DARWIN
+OPENGL = -framework OpenGL
+GLUT   = -framework GLUT
+else
+OPENGL = -lGL
+GLUT   = -lGLU
+endif
+
 MUSIC_INCLUDE = -I$(top_srcdir)/src -I$(top_builddir)/src
 
  music_SOURCES = music.cc
@@ -48,7 +56,7 @@ MUSIC_INCLUDE = -I$(top_srcdir)/src -I$(top_builddir)/src
 
  viewevents_SOURCES = viewevents.cpp VisualiseNeurons.cpp VisualiseNeurons.h
  viewevents_CXXFLAGS = $(MUSIC_INCLUDE) @MPI_CXXFLAGS@
- viewevents_LDADD = $(top_builddir)/src/libmusic.la @MPI_LDFLAGS@  -lglut -lGL -lGLU -lpthread
-
+ viewevents_LDADD = $(top_builddir)/src/libmusic.la @MPI_LDFLAGS@  -lglut -lpthread
+ viewevents_LDFLAGS = $(OPENGL) $(GLUT)
 
 MKDEP = gcc -M $(DEFS) $(INCLUDES) $(CPPFLAGS) $(CFLAGS)

--- a/utils/VisualiseNeurons.h
+++ b/utils/VisualiseNeurons.h
@@ -19,7 +19,11 @@
 // VisualiseNeurons.h written by Johannes Hjorth, hjorth@nada.kth.se
 
 
+#ifdef __APPLE__
+#include <OpenGL/gl.h>
+#else
 #include <GL/gl.h>
+#endif
 #include <GL/freeglut.h>
 #include <math.h>
 #include <mpi.h>


### PR DESCRIPTION
It has been recently merged a PR regarding this topic but for the last version of MUSIC, using OpenGL, it is not enough. Glut and OpenGL need to be linked against the appropriate frameworks and gl.h has a different location on macOS.

Thanks,
Bernardo