### PR TITLE
Throw error if no config was found for one rank

### DIFF
--- a/src/application_mapper.cc
+++ b/src/application_mapper.cc
@@ -183,11 +183,16 @@ void
         // NOTE: default configuration is preserved
         config->resetDict();
       }
+
+    if (n_selections != 1)
+      {
+        std::ostringstream msg;
+	msg << "no configuration found for one rank. This is most likely caused by launching MUSIC with too many processes. " << std::endl;
+	error0 (msg.str ());
+      }
+
     delete config;
     assert(config_->getDict().size() != 0);
-
-    // NOTE: given rank -1 causes an assertion failure
-    assert(n_selections == 1);
   }
 
 


### PR DESCRIPTION
This is my suggestion for fixing #43. Since one can not ask MPI at this point for this rank and for nranks, this seemed like the easiest solution. The `if` clause makes the `assert` at the end of the function unnecessary.