### PR TITLE
Improve installation instructions in README

### DIFF
--- a/README
+++ b/README
@@ -37,7 +37,8 @@ MUSIC can be built and installed using the generic installation
 instructions found in the file INSTALL.  At the top of the source
 distribution directory, do:
 
-./configure
+./autogen.sh
+./configure --prefix=<PREFIX>
 make
 make install
 


### PR DESCRIPTION
This PR improves the installation instructions in the README file. Before running configure, this file needs to be generated by autotools via `autogen.sh`, also as  a best practice users should always set a prefix to avoid installing MUSIC globally.