### PR TITLE
Set np=1 in default dictionary

### DIFF
--- a/src/configuration.cc
+++ b/src/configuration.cc
@@ -279,6 +279,10 @@ namespace MUSIC {
   {
     if (defaultConfig_ == NULL)
       defaultConfig_ = new Configuration();
+
+    // set default values here
+    defaultConfig_->insert ("np", "1");
+
     return defaultConfig_;
   }
 


### PR DESCRIPTION
This sets np to one in case no value is provided in the config dictionary. Let me know whether this is the correct place to define the default values.
Fixes #45 