### PR TITLE
Add function to load boolean values from config

### DIFF
--- a/src/configuration.cc
+++ b/src/configuration.cc
@@ -230,6 +230,24 @@ namespace MUSIC {
     return true; // Doesn't happen! Just for compiler!
   }
 
+  bool
+  Configuration::lookup (std::string name, bool* result)
+  {
+    std::map<std::string, std::string>::iterator pos = dict_.find (name);
+    if (pos == dict_.end ())
+      return defaultConfig_ && defaultConfig_->lookup (name, result);
+
+    std::istringstream iss(pos->second);
+    if (! (iss >> std::boolalpha >> *result).fail ())
+      return true;
+
+    std::ostringstream oss;
+    oss << "var " << name << " given wrong type (" << pos->second
+	<< "; expected bool) in config file";
+    error(oss.str ());
+    return true; // Doesn't happen! Just for compiler!
+  }
+
   std::string
   Configuration::Name ()
   {

--- a/src/music/configuration.hh
+++ b/src/music/configuration.hh
@@ -64,6 +64,8 @@ namespace MUSIC {
 
     bool lookup(std::string name, std::string* result);
 
+    bool lookup (std::string name, bool* result);
+
     void insert (std::string name, std::string value);
 
     const ConfigDict &getDict();

--- a/src/music/setup.hh
+++ b/src/music/setup.hh
@@ -67,6 +67,8 @@ namespace MUSIC {
 
     bool config (string var, double* result);
 
+    bool config (string var, bool* result);
+
     ContInputPort* publishContInput (string identifier);
 
     ContOutputPort* publishContOutput (string identifier);

--- a/src/setup.cc
+++ b/src/setup.cc
@@ -398,6 +398,13 @@ namespace MUSIC {
     return config_->lookup (var, result);
   }
 
+
+  bool
+  Setup::config (string var, bool* result)
+  {
+    return config_->lookup (var, result);
+  }
+
   
   ContInputPort*
   Setup::publishContInput (std::string identifier)


### PR DESCRIPTION
This PR adds a function that allows loading of boolean values from a config. Values need to be defined as `true`/`false`. See here https://github.com/incf-music/music-adapters/pull/5 for a use case.