### PR TITLE
Add missing `using` directives

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -25,7 +25,7 @@ case "$MPI_CXX" in
         SYSGUESS=openmpi
         CXX="`mpicxx -showme | sed -e 's/^\([^ ]*\).*/\1/'`"
       else
-        changequote([, ])      
+        changequote([, ])
         AC_MSG_ERROR([
 Confused when trying to determine MPI_CXX, MPI_CXXFLAGS etc.
 Please set them manually.])
@@ -182,7 +182,7 @@ Could not determine proper value for MPI_LDFLAGS.  Please see README.])
   echo "$MPI_LDFLAGS"
 fi
 
-CXXFLAGS="-g -O3"
+CXXFLAGS="-g -O3 -std=c++11"
 
 #if test "$ac_test_CXXFLAGS" != set; then
 #  if test "$CXXFLAGS" = "-O2"; then
@@ -239,7 +239,7 @@ AC_MSG_RESULT($ac_have_cxx_mpi_init_thread)
 AC_ARG_ENABLE(mpi,
               [  --disable-mpi           disable mpi support],
               MUSIC_USE_MPI="$enableval", MUSIC_USE_MPI="yes")
-if test $MUSIC_USE_MPI = yes ; then 
+if test $MUSIC_USE_MPI = yes ; then
   MUSIC_USE_MPI=1
   MPI_UTILS="eventsource eventsink eventselect eventgenerator eventcounter eventlogger contsink messagesource"
   EXAMPLESDIR="examples"
@@ -254,7 +254,7 @@ AM_CONDITIONAL([COND_USE_MPI], [test x$MUSIC_USE_MPI = x1])
 AC_ARG_ENABLE(isend,
               [  --disable-isend          disable isend],
               MUSIC_ISENDWAITALL="$enableval", MUSIC_ISENDWAITALL="yes")
-if test $MUSIC_ISENDWAITALL = yes ; then 
+if test $MUSIC_ISENDWAITALL = yes ; then
   MUSIC_ISENDWAITALL=1
 else
   MUSIC_ISENDWAITALL=0
@@ -263,7 +263,7 @@ fi
 AC_ARG_ENABLE(anysource,
               [  --disable-anysource      disable any source receive],
               MUSIC_ANYSOURCE="$enableval", MUSIC_ANYSOURCE="yes")
-if test $MUSIC_ANYSOURCE = yes ; then 
+if test $MUSIC_ANYSOURCE = yes ; then
   MUSIC_ANYSOURCE=1
 else
   MUSIC_ANYSOURCE=0
@@ -341,7 +341,7 @@ AS_IF([test "x$with_python" != "xno"],
 
 AS_IF([test "x$have_python" = "xyes"], [
     PYTHON_INC=`$PYTHON -c 'import sys; from distutils import sysconfig; sys.stdout.write(sysconfig.get_python_inc())'`
-    AC_CHECK_FILE(["${PYTHON_INC}/Python.h"], 
+    AC_CHECK_FILE(["${PYTHON_INC}/Python.h"],
     		  [PYMUSIC_CPPFLAGS="-I${PYTHON_INC}"; PYBUFFER_CPPFLAGS="-I${PYTHON_INC}"],
                   [have_python=no])
 ])
@@ -395,7 +395,7 @@ ROS_SUBDIR=""
 AS_IF([test "x$with_ros" = "xyes"], [ROS_SUBDIR="ros"], [with_ros=no])
 AC_MSG_RESULT([$with_ros])
 
-# if ROS is to be compiled 
+# if ROS is to be compiled
 if test "x$with_ros" = "xyes" ; then
  AC_CONFIG_FILES(ros/Makefile)
  AC_CONFIG_FILES(ros/adapters/Makefile)

--- a/src/connector.cc
+++ b/src/connector.cc
@@ -106,7 +106,7 @@ namespace MUSIC {
   void Connector::spatialNegotiation (SpatialNegotiator * spatialNegotiator_)
   {
 
-    if (spatialNegotiator_ == NULL)
+    if (spatialNegotiator_ == nullptr)
       error ("spatialNegotiator was not initialized");
     std::map<int, Subconnector*> subconnectors;
     NegotiationIterator i
@@ -123,7 +123,7 @@ namespace MUSIC {
   	else
   	  {
   	    subconn = makeSubconnector (i->rank ());
-  	    if(subconn == NULL)
+  	    if(subconn == nullptr)
 	      error ("Subconnector was not initialized");
   	    subconnectors.insert (std::make_pair (i->rank (), subconn));
   	    rsubconn.push_back (subconn);
@@ -268,20 +268,20 @@ namespace MUSIC {
 					    MPI::Datatype data_type)
     : Connector (connInfo, indices, type, comm),
       ContConnector (sampler, data_type),
-      connector(NULL)
+      connector(nullptr)
   {
   }
 
   ContOutputConnector::ContOutputConnector (   Sampler& sampler,  MPI::Datatype type)
     :  ContConnector (sampler, type),
-       connector(NULL)
+       connector(nullptr)
   {
   }
 
 
   ContOutputConnector::~ContOutputConnector()
   {
-    if (connector != NULL)
+    if (connector != nullptr)
       delete connector;
   }
 
@@ -464,7 +464,7 @@ namespace MUSIC {
     : Connector (connInfo, indices, type, comm),
       ContConnector (sampler, data_type),
       delay_ (delay),
-      connector(NULL)
+      connector(nullptr)
   {
   }
 
@@ -472,14 +472,14 @@ namespace MUSIC {
   ContInputConnector::ContInputConnector ( Sampler& sampler, MPI::Datatype type,  double delay)
     : ContConnector (sampler, type),
       delay_ (delay),
-      connector(NULL)
+      connector(nullptr)
   {
   }
 
 
   ContInputConnector::~ContInputConnector()
   {
-    if (connector != NULL)
+    if (connector != nullptr)
       delete connector;
   }
 
@@ -849,7 +849,7 @@ error( "LOCAL Indices are not supported with MUSIC_ANYSOURCE");
    ********************************************************************/
 
   CollectiveConnector::CollectiveConnector (bool high)
-    : high_ (high), subconnector_ (NULL)
+    : high_ (high), subconnector_ (nullptr)
   {
     //idFlag_ = makeFlag ();
   }
@@ -885,7 +885,7 @@ error( "LOCAL Indices are not supported with MUSIC_ANYSOURCE");
   {
     std::multimap< int, Interval> intrvs
       = *static_cast< std::multimap< int, Interval>*> (param);
-    if (subconnector_ == NULL)
+    if (subconnector_ == nullptr)
       {
 	subconnector_ = new ContCollectiveSubconnector (intrvs,
 							width (),
@@ -897,7 +897,7 @@ error( "LOCAL Indices are not supported with MUSIC_ANYSOURCE");
 
 
   EventCollectiveConnector::EventCollectiveConnector (bool high)
-    : CollectiveConnector (high), router_ (NULL)
+    : CollectiveConnector (high), router_ (nullptr)
   {
     idFlag_ = makeFlag (this);
   }
@@ -906,7 +906,7 @@ error( "LOCAL Indices are not supported with MUSIC_ANYSOURCE");
   Subconnector*
   EventInputCollectiveConnector::makeSubconnector (void *param)
   {
-    if (subconnector_ == NULL)
+    if (subconnector_ == nullptr)
       subconnector_ = new EventInputCollectiveSubconnector (router_);
     return subconnector_;
   }
@@ -948,7 +948,7 @@ error( "LOCAL Indices are not supported with MUSIC_ANYSOURCE");
   {
     routingMap_input = new InputRoutingMap ();
     Subconnector* subconn
-      = EventInputCollectiveConnector::makeSubconnector (NULL);
+      = EventInputCollectiveConnector::makeSubconnector (nullptr);
     rsubconn.push_back (subconn);
     for (NegotiationIterator i = spatialNegotiator_->negotiateSimple (); !i.end (); ++i)
       addRoutingInterval (i->interval (), subconn);
@@ -973,7 +973,7 @@ error( "LOCAL Indices are not supported with MUSIC_ANYSOURCE");
    MPI::Intracomm comm,
    DirectRouter* router)
     : Connector (connInfo, indices, type, comm),
-      EventOutputConnector (NULL),
+      EventOutputConnector (nullptr),
       EventCollectiveConnector (false),
       directRouter_ (router)
   {
@@ -989,7 +989,7 @@ error( "LOCAL Indices are not supported with MUSIC_ANYSOURCE");
   EventOutputCollectiveConnector::makeSubconnector (void *param)
   {
     //  EventRouter * router_ = static_cast<EventRouter*>(param);
-    if(subconnector_ == NULL){
+    if(subconnector_ == nullptr){
       subconnector_ = new EventOutputCollectiveSubconnector ();
     }
     return subconnector_;
@@ -1000,7 +1000,7 @@ error( "LOCAL Indices are not supported with MUSIC_ANYSOURCE");
   {
     EventOutputCollectiveSubconnector* subconn
       = dynamic_cast<EventOutputCollectiveSubconnector*>
-      (EventOutputCollectiveConnector::makeSubconnector (NULL));
+      (EventOutputCollectiveConnector::makeSubconnector (nullptr));
     rsubconn.push_back (subconn);
     subconn->setRouter (directRouter_);
     //spatialNegotiator_->negotiateSimple ();

--- a/src/music/connector.hh
+++ b/src/music/connector.hh
@@ -216,6 +216,7 @@ namespace MUSIC {
       else
 	info.setRemoteLeader (receiverLeader ());
     }
+    using Connector::isInput;
     bool isInput () { return receiverNode_ == currentNode_; }
     int senderLeader () const { return senderLeader_; }
     int senderNProcs () const { return senderNProcs_; }
@@ -451,6 +452,7 @@ namespace MUSIC {
     Subconnector* subconnector_;
   public:
     CollectiveConnector (bool high);
+    using Connector::makeSubconnector;
     virtual Subconnector* makeSubconnector (void *param) = 0;
     void createIntercomm ();
     void freeIntercomm ();
@@ -461,6 +463,7 @@ namespace MUSIC {
     MPI::Datatype data_type;
   protected:
     ContCollectiveConnector( MPI::Datatype type, bool high);
+    using Connector::makeSubconnector;
     Subconnector* makeSubconnector (void *param);
   };
 
@@ -486,6 +489,8 @@ namespace MUSIC {
   void tick() { Connector::tick();};
 #endif // MUSIC_ANYSOURCE
   protected:
+    using Connector::spatialNegotiation;
+    using EventInputConnector::makeSubconnector;
     void spatialNegotiation ( SpatialNegotiator* spatialNegotiator_);
     void addRoutingInterval(IndexInterval i, Subconnector* subconn);
     Subconnector* makeSubconnector (void *param);
@@ -508,6 +513,8 @@ namespace MUSIC {
     void tick (){Connector::tick();};
 #endif //MUSIC_ISENDWAITALL
   protected:
+    using Connector::spatialNegotiation;
+    using EventOutputConnector::makeSubconnector;
     void spatialNegotiation ( SpatialNegotiator* spatialNegotiator_);
     Subconnector* makeSubconnector (void *param);
   };
@@ -526,6 +533,7 @@ namespace MUSIC {
   virtual void tick() {Connector::tick();};
 #endif // MUSIC_ANYSOURCE
   protected:
+    using Connector::spatialNegotiation;
     void spatialNegotiation ( SpatialNegotiator* spatialNegotiator_);
   private:
     void receiveRemoteCommRankID(std::map<int,int> &remoteToCollectiveRankMap);
@@ -544,6 +552,7 @@ namespace MUSIC {
     void tick (){Connector::tick();};
 #endif
   protected:
+    using Connector::spatialNegotiation;
     void spatialNegotiation ( SpatialNegotiator* spatialNegotiator_);
   private:
     void sendLocalCommRankID();

--- a/src/music/port.hh
+++ b/src/music/port.hh
@@ -117,6 +117,7 @@ namespace MUSIC {
   class ContOutputPort : public ContPort,
 			 public OutputPort,
 			 public TickingPort {
+    using OutputPort::mapImpl;
     void mapImpl (DataMap* indices, int maxBuffered);
     Connector* makeConnector (ConnectorInfo connInfo);
     friend class Implementer;
@@ -166,6 +167,7 @@ namespace MUSIC {
     void insertEvent (double t, LocalIndex id);
     EventOutputPort (Setup* s, std::string id);
 
+    using OutputPort::mapImpl;
     void mapImpl (IndexMap* indices,
 		  Index::Type type,
 		  int maxBuffered);
@@ -249,6 +251,7 @@ namespace MUSIC {
     void map (int maxBuffered);
     void insertMessage (double t, void* msg, size_t size);
   protected:
+    using OutputPort::mapImpl;
     void mapImpl (int maxBuffered);
     Connector* makeConnector (ConnectorInfo connInfo);
     friend class Implementer;

--- a/src/music/subconnector.hh
+++ b/src/music/subconnector.hh
@@ -125,6 +125,7 @@ namespace MUSIC {
 			    int receiverPortCode,
 			    MPI::Datatype type);
     void initialCommunication (double param);
+    using Subconnector::maybeCommunicate;
     void maybeCommunicate ();
     void send ();
     void flush (bool& dataStillFlowing);
@@ -144,6 +145,7 @@ namespace MUSIC {
 			   MPI::Datatype type);
     BIFO* inputBuffer () { return &buffer_; }
     void initialCommunication (double initialBufferedTicks);
+    using Subconnector::maybeCommunicate;
     void maybeCommunicate ();
     void receive ();
     void flush (bool& dataStillFlowing);
@@ -187,6 +189,7 @@ namespace MUSIC {
  			    int remoteRank,
  			    int receiverRank,
  			    int receiverPortCode);
+     using Subconnector::maybeCommunicate;
  	 void maybeCommunicate ();
      virtual void receive () {};
      virtual void flush (bool& dataStillFlowing);
@@ -239,6 +242,7 @@ namespace MUSIC {
 			       int remoteRank,
 			       int receiverPortCode,
 			       FIBO* buffer);
+    using Subconnector::maybeCommunicate;
     void maybeCommunicate ();
     void send ();
     void flush (bool& dataStillFlowing);
@@ -256,6 +260,7 @@ namespace MUSIC {
 			      int receiverRank,
 			      int receiverPortCode,
 			      MessageHandler* mh);
+    using Subconnector::maybeCommunicate;
     void maybeCommunicate ();
     void receive ();
     void flush (bool& dataStillFlowing);
@@ -274,6 +279,7 @@ namespace MUSIC {
   protected:
     virtual ~CollectiveSubconnector ();
     CollectiveSubconnector (MPI::Intracomm intracomm);
+    using Subconnector::maybeCommunicate;
     void maybeCommunicate ();
     int calcCommDataSize (int local_data_size);
     std::vector<char> getCommData(char *cur_buff, int size);
@@ -307,6 +313,7 @@ namespace MUSIC {
     void fillOutputBuffer ();
 
     void flush (bool& dataStillFlowing) { }
+    using Subconnector::maybeCommunicate;
     void maybeCommunicate () { }
   };
 
@@ -324,6 +331,7 @@ namespace MUSIC {
     // the following is part of the MultiConnector protocol
     void processData (void* data, unsigned int size);
   private:
+    using Subconnector::maybeCommunicate;
     void maybeCommunicate () { }
   };
 
@@ -353,6 +361,7 @@ namespace MUSIC {
 	void freeAllgathervArrays ();
       }
       void initialCommunication (double initialBufferedTicks);
+      using Subconnector::maybeCommunicate;
       void maybeCommunicate ();
       void flush (bool& dataStillFlowing);
     private:


### PR DESCRIPTION
Compiling NEST with MUSIC support, while using the `-Woverloaded-virtual` flag, generates a great deal of warnings, both from NEST code and from code included from MUSIC. These warnings are related to function declarations hiding virtual functions from the base class. I am in the process of fixing issue in the NEST code (see nest/nest-simulator#1377), but CI fails because of the amount of warnings generated when compiling NEST with MUSIC support.

This PR solves the issue indicated by the warnings in MUSIC code as well, by adding `using` directives to make the base class functions accessible. In `connector.cc` the `NULL` macro had to be replaced by `nullptr` to help the compiler select the right overloaded function.