### PR TITLE
Cray XC case added

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -69,6 +69,11 @@ Please set them manually.])
       AC_DEFINE(CRAY_XE6, 1, [Define if this is a Cray XE6 system.])
       CC=cc
       CXX=CC
+    elif uname -r | grep -q 4.12.14-197.56-default; then
+      SYSGUESS=cray_xc
+      AC_DEFINE(CRAY_XC, 1, [Define if this is a Cray XC system.])
+      CC=cc
+      CXX=CC
     else
       SYSGUESS=unknown
     fi
@@ -110,6 +115,9 @@ else
     cray_xe6)
       MPI_CXXFLAGS=""
       ;;
+    cray_xc)
+      MPI_CXXFLAGS=""
+      ;;
     bgq_seq)
       MPI_CXXFLAGS=""
       enable_shared=no
@@ -146,6 +154,9 @@ else
     cray_xe6)
       MPI_CFLAGS=""
       ;;
+    cray_xc)
+      MPI_CFLAGS=""
+      ;;
     bgq_seq)
       MPI_CFLAGS=""
       enable_shared=no
@@ -171,7 +182,7 @@ else
     openmpi)
       MPI_LDFLAGS="`mpicxx -showme:link`"
       ;;
-    bgp|bgq|cray_xe6|bgq_seq)
+    bgp|bgq|cray_xe6|cray_xc|bgq_seq)
       MPI_LDFLAGS=""
       ;;
     *)

--- a/configure.ac
+++ b/configure.ac
@@ -69,9 +69,9 @@ Please set them manually.])
       AC_DEFINE(CRAY_XE6, 1, [Define if this is a Cray XE6 system.])
       CC=cc
       CXX=CC
-    elif uname -r | grep -q 4.12.14-197.56-default; then
-      SYSGUESS=cray_xc
-      AC_DEFINE(CRAY_XC, 1, [Define if this is a Cray XC system.])
+    elif hostname | grep -q daint; then
+      SYSGUESS=cray_xc_daint
+      AC_DEFINE(CRAY_XC_DAINT, 1, [Define if this is the Cray XC Daint system.])
       CC=cc
       CXX=CC
     else
@@ -115,7 +115,7 @@ else
     cray_xe6)
       MPI_CXXFLAGS=""
       ;;
-    cray_xc)
+    cray_xc_daint)
       MPI_CXXFLAGS=""
       ;;
     bgq_seq)
@@ -154,7 +154,7 @@ else
     cray_xe6)
       MPI_CFLAGS=""
       ;;
-    cray_xc)
+    cray_xc_daint)
       MPI_CFLAGS=""
       ;;
     bgq_seq)
@@ -182,7 +182,7 @@ else
     openmpi)
       MPI_LDFLAGS="`mpicxx -showme:link`"
       ;;
-    bgp|bgq|cray_xe6|cray_xc|bgq_seq)
+    bgp|bgq|cray_xe6|cray_xc_daint|bgq_seq)
       MPI_LDFLAGS=""
       ;;
     *)

--- a/mpidep/mpidep.cc
+++ b/mpidep/mpidep.cc
@@ -31,7 +31,7 @@ extern "C" {
 
 // Implementation-dependent code
 
-#ifndef CRAY_XE6
+#if !defined CRAY_XE6 && !defined CRAY_XC
 #ifdef HAVE_RTS_GET_PERSONALITY
 #define BGL
 #else
@@ -64,7 +64,7 @@ extern "C" {
  * argc and argv (MPICH) or through the environment (OpenMPI).
  *
  * return -1 on failure
- */ 
+ */
 
 int
 getRank (int argc, char *argv[])
@@ -135,6 +135,13 @@ getRank (int argc, char *argv[])
       ++n;
     }
   return -1;
+#endif
+#ifdef CRAY_XC
+  char* rank_char = std::getenv("SLURM_PROCID");
+  std::istringstream rank_iss(rank_char);
+  int rank_int;
+  rank_iss >> rank_int;
+  return rank_int;
 #endif
 }
 

--- a/mpidep/mpidep.cc
+++ b/mpidep/mpidep.cc
@@ -31,7 +31,7 @@ extern "C" {
 
 // Implementation-dependent code
 
-#if !defined CRAY_XE6 && !defined CRAY_XC
+#if !defined CRAY_XE6 && !defined CRAY_XC_DAINT
 #ifdef HAVE_RTS_GET_PERSONALITY
 #define BGL
 #else
@@ -136,7 +136,7 @@ getRank (int argc, char *argv[])
     }
   return -1;
 #endif
-#ifdef CRAY_XC
+#ifdef CRAY_XC_DAINT
   char* rank_char = std::getenv("SLURM_PROCID");
   std::istringstream rank_iss(rank_char);
   int rank_int;


### PR DESCRIPTION
Hello, I'm opening this (draft, for the moment) PR in order to add an additional Cray system case. Particularly, the modified code is a workaround to build MUSIC on PizDaint (Cray XC) for a CSCS user. I've used the same linux command of the existing  Cray (XE6) case to identify the system in configure.ac, in order to avoid too many changes, but for sure is not the best solution: we could probably use the node interconnect technology to identify the system. If you think this PR is useful for MUSIC user community please let me know, I will try to finalize the system identification issue. Thank you!