### PR TITLE
Correcting grammatical error: Changing "is" to "are"

### DIFF
--- a/README
+++ b/README
@@ -11,7 +11,7 @@ different time steps and different data allocation strategies.
 This is the MUSIC pilot implementation.
 
 The two most important components built from this software
-distribution is the music library `libmusic.a' and the music utility
+distribution are the music library `libmusic.a' and the music utility
 `music'.  A MUSIC-aware simulator links against the C++ library and
 can be launched using mpirun together with the music utility as
 described below.  MUSIC can also be used from a C program using the


### PR DESCRIPTION
This PR corrects a grammatical error in the documentation. The sentence:

"The two most important components built from this software distribution is the music library libmusic.a and the music utility music."

has been updated to:

"The two most important components built from this software distribution are the music library libmusic.a and the music utility music."

Changes Made
Changed the verb "is" to "are" to agree with the plural subject ("components").
This change ensures proper grammar and improves readability.

Testing
No code functionality is affected; this is a documentation change only.