### PR TITLE
#65: Resolved Installation issues for ubuntu

### DIFF
--- a/extras/Makefile.am
+++ b/extras/Makefile.am
@@ -1,6 +1,12 @@
-## Process this file with Automake to create Makefile.in
+# Define binary programs to be installed
+bin_PROGRAMS = music
 
+# Define scripts to be installed
+bin_SCRIPTS = music_mpirun
+
+# Include files for distribution
 EXTRA_DIST = music_mpirun
 
+# Custom installation hook 
 install-data-hook:
-	@INSTALL_PROGRAM@ $(srcdir)/music@LAUNCHSTYLE@ $(DESTDIR)$(bindir)/musicrun
+    @INSTALL_PROGRAM@ $(srcdir)/music_mpirun $(DESTDIR)$(bindir)/music_mpirun


### PR DESCRIPTION
The changes to the `Makefile.am` make sure the `music_mpirun` script is included in the project and installed correctly. The script was added to `EXTRA_DIST` so it’s part of the distribution package. It was also added to `bin_SCRIPTS` to install it into the system’s `bin` directory during `make install`. These changes ensure everything works smoothly with fewer extra steps.