### PR TITLE
Fix configuration validation and add default stoptime to contsink

### DIFF
--- a/src/application_map.cc
+++ b/src/application_map.cc
@@ -22,6 +22,7 @@
 #include "music/mpi_utils.hh"
 #endif
 #include "music/ioutils.hh"
+#include "music/error.hh"
 #include <iostream>
 #include <fstream>
 namespace MUSIC {
@@ -55,6 +56,8 @@ namespace MUSIC {
   void
   ApplicationMap::add (std::string name, int n, int c)
   {
+    if (lookup(name) != NULL)
+      error ("Application label " + name + " is already used");
     push_back (ApplicationInfo (name, n, c));
   }
 

--- a/src/configuration.cc
+++ b/src/configuration.cc
@@ -131,7 +131,7 @@ namespace MUSIC {
     applications_->read (env);
     env.ignore ();
     std::map<int, int> leaders = applications_->assignLeaders( Name ());
-    connectivityMap_->read (env, leaders);
+    connectivityMap_->read (env, leaders, applications_);
     // parse config string
     while (!env.eof ())
       {

--- a/src/connectivity.cc
+++ b/src/connectivity.cc
@@ -23,6 +23,7 @@
 #include "music/debug.hh"
 
 #include "music/connectivity.hh"
+#include "music/application_map.hh"
 #include "music/ioutils.hh"
 #include "music/error.hh"
 
@@ -175,7 +176,7 @@ namespace MUSIC {
   
 
   void
-  Connectivity::read (std::istringstream& in, std::map<int, int> leaders)
+  Connectivity::read (std::istringstream& in, std::map<int, int> leaders, ApplicationMap* applications)
   {
     int nPorts;
     in >> nPorts;
@@ -198,6 +199,8 @@ namespace MUSIC {
 	  {
 	    in.ignore ();
 	    std::string recApp = IOUtils::read (in);
+	    if (applications->lookup(recApp) == NULL)
+	      error ("Connection to non-existent application: " + recApp);
 	    in.ignore ();
 	    std::string recPort = IOUtils::read (in);
 	    in.ignore ();

--- a/src/music/connectivity.hh
+++ b/src/music/connectivity.hh
@@ -23,6 +23,7 @@
 #include <map>
 
 namespace MUSIC {
+  class ApplicationMap;
 /*
  * Communication Type (<COLLECTIVE, POINTTOPOINT>)
  * Processing Method (<TREE, TABLE>)
@@ -229,7 +230,7 @@ namespace MUSIC {
 
     void write (std::ostringstream& out);
 
-    void read (std::istringstream& in, std::map<int, int> leaders);
+    void read (std::istringstream& in, std::map<int, int> leaders, ApplicationMap* applications);
   };
 
 }

--- a/utils/contsink.cc
+++ b/utils/contsink.cc
@@ -117,7 +117,8 @@ main (int argc, char* argv[])
   contdata->map (&dmap, delay, interpolate);
 
   double stoptime;
-  setup->config ("stoptime", &stoptime);
+  if (!setup->config ("stoptime", &stoptime))
+    stoptime = 1.0;
 
   MUSIC::Runtime* runtime = new MUSIC::Runtime (setup, timestep);
 


### PR DESCRIPTION
This PR improves configuration validation by ensuring application labels are unique and verifying that connection references point to existing applications, preventing potential crashes or undefined behavior. Additionally, it sets a default `stoptime` of 1.0s for the `contsink` utility to ensure smoother execution when the argument is omitted. These changes enhance the tool's stability and error reporting.