### PR TITLE
Stop probing old autotools versions

### DIFF
--- a/aclocal.sh
+++ b/aclocal.sh
@@ -1,10 +1,7 @@
 #!/bin/sh
 
 if test -z "$ACLOCAL" ; then
- for each in aclocal-1.10 aclocal-1.9 aclocal-1.8 aclocal-1.7 aclocal-1.6 aclocal ; do
-   ACLOCAL=$each
-   if test -n "`which $each 2>/dev/null`" ; then break ; fi
- done
+ ACLOCAL=aclocal
 fi
 
 ACDIR=`which $ACLOCAL`

--- a/autogen.sh
+++ b/autogen.sh
@@ -6,10 +6,7 @@
 }
 
 if test -z "$AUTOMAKE" ; then
- for each in automake-1.10 automake-1.9 automake-1.8 automake-1.7 automake-1.6 automake ; do
-   AUTOMAKE=$each
-   if test -n "`which $each 2>/dev/null`" ; then break ; fi
- done
+ AUTOMAKE=automake
 fi
 
 if [ `uname -s` = Darwin ] ; then


### PR DESCRIPTION
Fixes #20.

This updates the autotools bootstrap helpers to use the standard `aclocal` and `automake` commands instead of probing for old versioned binaries such as `aclocal-1.10` and `automake-1.10`. The existing `ACLOCAL` and `AUTOMAKE` environment overrides are preserved, so callers can still provide explicit tool paths when needed.

Validation:
- `sh -n aclocal.sh`
- `sh -n autogen.sh`
- `rg 'aclocal-1\.|automake-1\.' aclocal.sh autogen.sh`
- Verified with temporary fake tools outside the repository that the scripts invoke `aclocal` and `automake` only.

Full autotools regeneration was not run locally because this environment does not provide the required autotools binaries.